### PR TITLE
Common - Add support for booleans in ACE_IsEngineer

### DIFF
--- a/addons/common/functions/fnc_getUnitTraitsNames.sqf
+++ b/addons/common/functions/fnc_getUnitTraitsNames.sqf
@@ -16,6 +16,8 @@ if (_medicClass > 0) then {
 };
 
 private _engineerClass = _unit getVariable ["ACE_IsEngineer", parseNumber (_unit getUnitTrait "engineer")];
+// ACE_IsEngineer can be true/false or 0/1/2, ensure it's a number
+_engineerClass = [0, 1, 2] select _engineerClass;
 if (_engineerClass > 0) then {
   _traits pushBack (localize ([
     LSTRING(AdvEngineer),


### PR DESCRIPTION
Fixes script error in `getUnitTraitNames` if `ACE_IsEngineer` is a boolean.